### PR TITLE
Ensure we don't calculate provisioning interface incorrectly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,0 @@
-FROM docker.io/centos:centos7
-
-RUN yum install -y iproute && yum clean all
-
-COPY ./set-static-ip /set-static-ip
-COPY ./refresh-static-ip /refresh-static-ip

--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,7 +1,8 @@
-FROM rhel8:latest
+FROM ubi8
 
-RUN yum install -y iproute && yum clean all
+RUN dnf install -y iproute jq && \
+      dnf clean all && \
+      rm -rf /var/cache/{yum,dnf}/*
 
 COPY ./set-static-ip /set-static-ip
 COPY ./refresh-static-ip /refresh-static-ip
-

--- a/refresh-static-ip
+++ b/refresh-static-ip
@@ -11,11 +11,24 @@ if [ -z "$PROVISIONING_INTERFACE" ]; then
   # hard dependency of forcing users to specify the interface, we detect
   # which network interface has the IP's from the machine network.
   IP_ONLY=$(echo "$PROVISIONING_IP" | cut -d/ -f1)
-  PROVISIONING_INTERFACE=$(ip route get "$IP_ONLY" | grep -Po '(?<=(dev )).*(?= src| proto)')
+
+  # See if we already have the IP on an interface
+  PROVISIONING_INTERFACE=$(ip -j addr | jq -r -c ".[].addr_info[] | select(.local == \"$IP_ONLY\") | .label")
+
+  # If not, let's figure out what interface it should go on
+  if [ -z "$PROVISIONING_INTERFACE" ]; then
+    PROVISIONING_INTERFACE=$(ip -j route get "$IP_ONLY" | jq -r '.[] | select(.dev != "lo") | .dev')
+  fi
 else
   # Get rid of any DHCP addresses only if we have a dedicated
   # provisioning interface
   /usr/sbin/ip address flush dev "$PROVISIONING_INTERFACE"
+fi
+
+if [ -z "$PROVISIONING_INTERFACE" ]; then
+  ip addr show
+  echo "ERROR: Could not find suitable interface for \"$PROVISIONING_IP\""
+  exit 1
 fi
 
 # In case the IP has lapsed since we set it in the init container.

--- a/set-static-ip
+++ b/set-static-ip
@@ -11,11 +11,24 @@ if [ -z "$PROVISIONING_INTERFACE" ]; then
   # hard dependency of forcing users to specify the interface, we detect
   # which network interface has the IP's from the machine network.
   IP_ONLY=$(echo "$PROVISIONING_IP" | cut -d/ -f1)
-  PROVISIONING_INTERFACE=$(ip route get "$IP_ONLY" | grep -Po '(?<=(dev )).*(?= src| proto)')
+
+  # See if we already have the IP on an interface
+  PROVISIONING_INTERFACE=$(ip -j addr | jq -r -c ".[].addr_info[] | select(.local == \"$IP_ONLY\") | .label")
+
+  # If not, let's figure out what interface it should go on
+  if [ -z "$PROVISIONING_INTERFACE" ]; then
+    PROVISIONING_INTERFACE=$(ip -j route get "$IP_ONLY" | jq -r '.[] | select(.dev != "lo") | .dev')
+  fi
 else
   # Get rid of any DHCP addresses only if we have a dedicated
   # provisioning interface
   /usr/sbin/ip address flush dev "$PROVISIONING_INTERFACE"
+fi
+
+if [ -z "$PROVISIONING_INTERFACE" ]; then
+  ip addr show
+  echo "ERROR: Could not find suitable interface for \"$PROVISIONING_IP\""
+  exit 1
 fi
 
 # Need this to be long enough to bring up the pod with the ip refresh in it.


### PR DESCRIPTION
When there's no provisioning network, we use a static ip on the external
network. There's a few concerns with the existing code: after the IP
is on an interface, our 'route' command returns `lo` as the interface.

We need to check first if the IP is already configured, and only after
that try to figure out the right interface. This also changes the
scripts to exclude `lo` from any possible interface.

This moves Dockerfile.ocp to use the ubi8 containers, and since this can
be built locally there's no reason to keep 2 copies of a dockerfile
around anymore, so the non-OCP Dockerfile is removed here.