### PR TITLE
Bug 1901040: Force addr_gen_mode to "0" on PROVISIONING_INTERFACE

### DIFF
--- a/refresh-static-ip
+++ b/refresh-static-ip
@@ -35,6 +35,9 @@ fi
 /usr/sbin/ip addr add "$PROVISIONING_IP" dev "$PROVISIONING_INTERFACE" valid_lft 10 preferred_lft 10 || true
 
 while true; do
+    # Having addr_gen_mode set to 1 doesn't appear to work and
+    # ends up with the interface loosing its link-local IP periodically.
+    echo 0 > "/proc/sys/net/ipv6/conf/$PROVISIONING_INTERFACE/addr_gen_mode"
     /usr/sbin/ip addr change "$PROVISIONING_IP" dev "$PROVISIONING_INTERFACE" valid_lft 10 preferred_lft 10
     sleep 5
 done


### PR DESCRIPTION
Having addr_gen_mode set to 1 doesn't appear to work and
ends up with the interface loosing its link-local IP periodically.