### PR TITLE
Bug 1918779: Toggle addr_gen_mode to 1 and back

### DIFF
--- a/refresh-static-ip
+++ b/refresh-static-ip
@@ -35,9 +35,11 @@ fi
 /usr/sbin/ip addr add "$PROVISIONING_IP" dev "$PROVISIONING_INTERFACE" valid_lft 10 preferred_lft 10 || true
 
 while true; do
-    # Having addr_gen_mode set to 1 doesn't appear to work and
-    # ends up with the interface loosing its link-local IP periodically.
-    echo 0 > "/proc/sys/net/ipv6/conf/$PROVISIONING_INTERFACE/addr_gen_mode"
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1908302
+    # Toggling addr_gen_mode prompts the link local address to be reapplied in cases
+    # where it is lost.
+    ip -o addr show dev "$PROVISIONING_INTERFACE" scope link | grep -q " fe80::" || \
+    ( echo 1 > "/proc/sys/net/ipv6/conf/$PROVISIONING_INTERFACE/addr_gen_mode" ; echo 0 > "/proc/sys/net/ipv6/conf/$PROVISIONING_INTERFACE/addr_gen_mode" )
     /usr/sbin/ip addr change "$PROVISIONING_IP" dev "$PROVISIONING_INTERFACE" valid_lft 10 preferred_lft 10
     sleep 5
 done


### PR DESCRIPTION
Setting addr_gen_mode to 0 only works to set the link-local
IP the first time. If this container moves to another node
and then moves back, it needs to be toggled to 1 and back
to take effect.