### PR TITLE
Add support for PROVISIONING_MACS

### DIFF
--- a/refresh-static-ip
+++ b/refresh-static-ip
@@ -6,35 +6,21 @@ if [ -z "$PROVISIONING_IP" ]; then
 fi
 
 if [ -z "$PROVISIONING_INTERFACE" ]; then
-  # If no provisioning interface is specified, then we're probably in
-  # the mode where the provisioning network is optional, so to avoid a
-  # hard dependency of forcing users to specify the interface, we detect
-  # which network interface has the IP's from the machine network.
-  IP_ONLY=$(echo "$PROVISIONING_IP" | cut -d/ -f1)
-
-  # See if we already have the IP on an interface
-  PROVISIONING_INTERFACE=$(ip -j addr | jq -r -c ".[].addr_info[] | select(.local == \"$IP_ONLY\") | .label")
-
-  # If not, let's figure out what interface it should go on
-  if [ -z "$PROVISIONING_INTERFACE" ]; then
-    PROVISIONING_INTERFACE=$(ip -j route get "$IP_ONLY" | jq -r '.[] | select(.dev != "lo") | .dev')
+  if [ -n "${PROVISIONING_MACS}" ]; then
+    for mac in ${PROVISIONING_MACS//,/ } ; do
+      if ip -br link show up | grep -q "$mac"; then
+        PROVISIONING_INTERFACE=$(ip -br link show up | grep "$mac" | cut -f 1 -d ' ')
+        break
+      fi
+    done
   fi
-else
-  # Get rid of any DHCP addresses only if we have a dedicated
-  # provisioning interface
-  /usr/sbin/ip address flush dev "$PROVISIONING_INTERFACE"
 fi
 
-if [ -z "$PROVISIONING_INTERFACE" ]; then
-  ip addr show
-  echo "ERROR: Could not find suitable interface for \"$PROVISIONING_IP\""
-  exit 1
-fi
+if [ -n "$PROVISIONING_INTERFACE" ]; then
+  # In case the IP has lapsed since we set it in the init container.
+  /usr/sbin/ip addr add "$PROVISIONING_IP" dev "$PROVISIONING_INTERFACE" valid_lft 10 preferred_lft 10 || true
 
-# In case the IP has lapsed since we set it in the init container.
-/usr/sbin/ip addr add "$PROVISIONING_IP" dev "$PROVISIONING_INTERFACE" valid_lft 10 preferred_lft 10 || true
-
-while true; do
+  while true; do
     # https://bugzilla.redhat.com/show_bug.cgi?id=1908302
     # Toggling addr_gen_mode prompts the link local address to be reapplied in cases
     # where it is lost.
@@ -42,5 +28,8 @@ while true; do
     ( echo 1 > "/proc/sys/net/ipv6/conf/$PROVISIONING_INTERFACE/addr_gen_mode" ; echo 0 > "/proc/sys/net/ipv6/conf/$PROVISIONING_INTERFACE/addr_gen_mode" )
     /usr/sbin/ip addr change "$PROVISIONING_IP" dev "$PROVISIONING_INTERFACE" valid_lft 10 preferred_lft 10
     sleep 5
-done
-
+  done
+else
+  echo "ERROR: Could not find suitable interface for \"$PROVISIONING_IP\""
+  exit 1
+fi

--- a/set-static-ip
+++ b/set-static-ip
@@ -6,32 +6,25 @@ if [ -z "$PROVISIONING_IP" ]; then
 fi
 
 if [ -z "$PROVISIONING_INTERFACE" ]; then
-  # If no provisioning interface is specified, then we're probably in
-  # the mode where the provisioning network is optional, so to avoid a
-  # hard dependency of forcing users to specify the interface, we detect
-  # which network interface has the IP's from the machine network.
-  IP_ONLY=$(echo "$PROVISIONING_IP" | cut -d/ -f1)
-
-  # See if we already have the IP on an interface
-  PROVISIONING_INTERFACE=$(ip -j addr | jq -r -c ".[].addr_info[] | select(.local == \"$IP_ONLY\") | .label")
-
-  # If not, let's figure out what interface it should go on
-  if [ -z "$PROVISIONING_INTERFACE" ]; then
-    PROVISIONING_INTERFACE=$(ip -j route get "$IP_ONLY" | jq -r '.[] | select(.dev != "lo") | .dev')
+  if [ -n "${PROVISIONING_MACS}" ]; then
+    for mac in ${PROVISIONING_MACS//,/ } ; do
+      if ip -br link show up | grep -q "$mac"; then
+        PROVISIONING_INTERFACE=$(ip -br link show up | grep "$mac" | cut -f 1 -d ' ')
+        break
+      fi
+    done
   fi
-else
-  # Get rid of any DHCP addresses only if we have a dedicated
-  # provisioning interface
-  /usr/sbin/ip address flush dev "$PROVISIONING_INTERFACE"
 fi
 
-if [ -z "$PROVISIONING_INTERFACE" ]; then
-  ip addr show
+if [ -n "$PROVISIONING_INTERFACE" ]; then
+  # Get rid of any DHCP addresses on the dedicated provisioning interface
+  /usr/sbin/ip address flush dev "$PROVISIONING_INTERFACE"
+
+  # Need this to be long enough to bring up the pod with the ip refresh in it.
+  # The refresh-static-ip container should lower this back to 10 seconds once it starts.
+  # The only time this will actually be set for 5 minutes is if the containers fail to come up.
+  /usr/sbin/ip addr add "$PROVISIONING_IP" dev "$PROVISIONING_INTERFACE" valid_lft 300 preferred_lft 300
+else
   echo "ERROR: Could not find suitable interface for \"$PROVISIONING_IP\""
   exit 1
 fi
-
-# Need this to be long enough to bring up the pod with the ip refresh in it.
-# The refresh-static-ip container should lower this back to 10 seconds once it starts.
-# The only time this will actually be set for 5 minutes is if the containers fail to come up.
-/usr/sbin/ip addr add "$PROVISIONING_IP" dev "$PROVISIONING_INTERFACE" valid_lft 300 preferred_lft 300


### PR DESCRIPTION
Also remove support for detecting interface by IP, since CBO no longer
starts this container in the case where the provisioning network
is disabled.

Also it only makes sense to flush IPs in set-static-ip not every
refresh.