### PR TITLE
METAL-67: Check PROVISONING_INTERFACE already has IP belong to different subset

### DIFF
--- a/set-static-ip
+++ b/set-static-ip
@@ -17,6 +17,17 @@ if [ -z "$PROVISIONING_INTERFACE" ]; then
 fi
 
 if [ -n "$PROVISIONING_INTERFACE" ]; then
+  # Check provisioning interface is already set to ip address
+  if [[ -n $(ip -o addr show dev "${PROVISIONING_INTERFACE}" scope global) ]]; then
+    # equality check can be done for IPv4, i.e. 172.22.0.3/24
+    # for IPv6 and dualstack(IPv4v6), fd00:1101::x/64 is used as fd00:1101::xxxx:xxxx:xxxx:xxxx/128
+    # Thus, we need to parse provisioning ip with '::'.
+    if ! ip -o addr show dev "${PROVISIONING_INTERFACE}" scope global | grep -q "${PROVISIONING_IP//::*/}" ; then
+      echo "ERROR: \"$PROVISIONING_INTERFACE\" is already set to ip address belong to different subset than \"$PROVISIONING_IP\""
+      exit 1
+    fi
+  fi
+
   # Get rid of any DHCP addresses on the dedicated provisioning interface
   /usr/sbin/ip address flush dev "$PROVISIONING_INTERFACE"
 


### PR DESCRIPTION
This PR adds validation to assure that `PROVISIONING_INTERFACE` is not
assigned IP address and if it is assigned, this IP address belongs to
same subset with `PROVISIONING_IP`.