### PR TITLE
Bug 2054770: Do case-insensitive comparison of MACs

### DIFF
--- a/refresh-static-ip
+++ b/refresh-static-ip
@@ -8,8 +8,8 @@ fi
 if [ -z "$PROVISIONING_INTERFACE" ]; then
   if [ -n "${PROVISIONING_MACS}" ]; then
     for mac in ${PROVISIONING_MACS//,/ } ; do
-      if ip -br link show up | grep -q "$mac"; then
-        PROVISIONING_INTERFACE=$(ip -br link show up | grep "$mac" | cut -f 1 -d ' ')
+      if ip -br link show up | grep -qi "$mac"; then
+        PROVISIONING_INTERFACE=$(ip -br link show up | grep -i "$mac" | cut -f 1 -d ' ')
         break
       fi
     done

--- a/set-static-ip
+++ b/set-static-ip
@@ -8,8 +8,8 @@ fi
 if [ -z "$PROVISIONING_INTERFACE" ]; then
   if [ -n "${PROVISIONING_MACS}" ]; then
     for mac in ${PROVISIONING_MACS//,/ } ; do
-      if ip -br link show up | grep -q "$mac"; then
-        PROVISIONING_INTERFACE=$(ip -br link show up | grep "$mac" | cut -f 1 -d ' ')
+      if ip -br link show up | grep -qi "$mac"; then
+        PROVISIONING_INTERFACE=$(ip -br link show up | grep -i "$mac" | cut -f 1 -d ' ')
         break
       fi
     done


### PR DESCRIPTION
PROVISIONING_MACS may contain MAC addresses with either upper- or
lower-case hex digits, but the output of the 'ip' command is always in
lowercase, so do a case-insensitive grep.