### PR TITLE
OCPBUGS-4501: Flush addresses on provisioning interface with global scope only

### DIFF
--- a/set-static-ip
+++ b/set-static-ip
@@ -29,7 +29,7 @@ if [ -n "$PROVISIONING_INTERFACE" ]; then
   fi
 
   # Get rid of any DHCP addresses on the dedicated provisioning interface
-  /usr/sbin/ip address flush dev "$PROVISIONING_INTERFACE"
+  /usr/sbin/ip address flush dev "$PROVISIONING_INTERFACE" scope global
 
   # Need this to be long enough to bring up the pod with the ip refresh in it.
   # The refresh-static-ip container should lower this back to 10 seconds once it starts.


### PR DESCRIPTION
The original purpose of the command is to flush addresses
added by DHCP, so we do not flush IPv6 link-local addresses
from the provisioniong interface.
This is a workaround for Network Manager bug described at
https://bugzilla.redhat.com/show_bug.cgi?id=2196441 in RHEL 9