### PR TITLE
OCPBUGS-38507: Fix subnet validation

### DIFF
--- a/Dockerfile.ocp
+++ b/Dockerfile.ocp
@@ -1,6 +1,6 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-base-openshift-4.18
 
-RUN dnf install -y iproute jq && \
+RUN dnf install -y iproute jq ipcalc && \
       dnf clean all && \
       rm -rf /var/cache/{yum,dnf}/*
 

--- a/refresh-static-ip
+++ b/refresh-static-ip
@@ -28,8 +28,11 @@ while true; do
   # https://bugzilla.redhat.com/show_bug.cgi?id=1908302
   # Toggling addr_gen_mode prompts the link local address to be reapplied in cases
   # where it is lost.
-  ip -o addr show dev "$PROVISIONING_INTERFACE" scope link | grep -q " fe80::" || \
-  ( echo 1 > "/proc/sys/net/ipv6/conf/$PROVISIONING_INTERFACE/addr_gen_mode" ; echo 0 > "/proc/sys/net/ipv6/conf/$PROVISIONING_INTERFACE/addr_gen_mode" )
+  if [ "$(ip -o -6 address show dev "${PROVISIONING_INTERFACE}" scope link)" = "" ]; then
+    echo 1 > "/proc/sys/net/ipv6/conf/${PROVISIONING_INTERFACE}/addr_gen_mode"
+    echo 0 > "/proc/sys/net/ipv6/conf/${PROVISIONING_INTERFACE}/addr_gen_mode"
+  fi
+
   /usr/sbin/ip addr change "$PROVISIONING_IP" dev "$PROVISIONING_INTERFACE" valid_lft 10 preferred_lft 10
 
   # OCPBUGS-14614: Remove route for provisioning network from lo if it exists

--- a/refresh-static-ip
+++ b/refresh-static-ip
@@ -8,8 +8,8 @@ fi
 if [ -z "$PROVISIONING_INTERFACE" ]; then
   if [ -n "${PROVISIONING_MACS}" ]; then
     for mac in ${PROVISIONING_MACS//,/ } ; do
-      if ip -br link show up | grep -qi "$mac"; then
-        PROVISIONING_INTERFACE=$(ip -br link show up | grep -i "$mac" | cut -f 1 -d ' ')
+      PROVISIONING_INTERFACE="$(ip -j link show up | jq -r ".[] | select(.address == \"${mac@L}\").ifname" | head -n 1)"
+      if [ -n "${PROVISIONING_INTERFACE}" ]; then
         break
       fi
     done

--- a/refresh-static-ip
+++ b/refresh-static-ip
@@ -16,24 +16,24 @@ if [ -z "$PROVISIONING_INTERFACE" ]; then
   fi
 fi
 
-if [ -n "$PROVISIONING_INTERFACE" ]; then
-  # In case the IP has lapsed since we set it in the init container.
-  /usr/sbin/ip addr add "$PROVISIONING_IP" dev "$PROVISIONING_INTERFACE" valid_lft 10 preferred_lft 10 || true
-
-  while true; do
-    # https://bugzilla.redhat.com/show_bug.cgi?id=1908302
-    # Toggling addr_gen_mode prompts the link local address to be reapplied in cases
-    # where it is lost.
-    ip -o addr show dev "$PROVISIONING_INTERFACE" scope link | grep -q " fe80::" || \
-    ( echo 1 > "/proc/sys/net/ipv6/conf/$PROVISIONING_INTERFACE/addr_gen_mode" ; echo 0 > "/proc/sys/net/ipv6/conf/$PROVISIONING_INTERFACE/addr_gen_mode" )
-    /usr/sbin/ip addr change "$PROVISIONING_IP" dev "$PROVISIONING_INTERFACE" valid_lft 10 preferred_lft 10
-
-    # OCPBUGS-14614: Remove route for provisioning network from lo if it exists
-    [[ "$PROVISIONING_IP" =~ : ]] && ip -o -6 route show "$PROVISIONING_IP" | grep " lo " | xargs -tr ip route del
-
-    sleep 5
-  done
-else
+if [ -z "${PROVISIONING_INTERFACE}" ]; then
   echo "ERROR: Could not find suitable interface for \"$PROVISIONING_IP\""
   exit 1
 fi
+
+# In case the IP has lapsed since we set it in the init container.
+/usr/sbin/ip addr add "$PROVISIONING_IP" dev "$PROVISIONING_INTERFACE" valid_lft 10 preferred_lft 10 || true
+
+while true; do
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1908302
+  # Toggling addr_gen_mode prompts the link local address to be reapplied in cases
+  # where it is lost.
+  ip -o addr show dev "$PROVISIONING_INTERFACE" scope link | grep -q " fe80::" || \
+  ( echo 1 > "/proc/sys/net/ipv6/conf/$PROVISIONING_INTERFACE/addr_gen_mode" ; echo 0 > "/proc/sys/net/ipv6/conf/$PROVISIONING_INTERFACE/addr_gen_mode" )
+  /usr/sbin/ip addr change "$PROVISIONING_IP" dev "$PROVISIONING_INTERFACE" valid_lft 10 preferred_lft 10
+
+  # OCPBUGS-14614: Remove route for provisioning network from lo if it exists
+  [[ "$PROVISIONING_IP" =~ : ]] && ip -o -6 route show "$PROVISIONING_IP" | grep " lo " | xargs -tr ip route del
+
+  sleep 5
+done

--- a/set-static-ip
+++ b/set-static-ip
@@ -16,26 +16,26 @@ if [ -z "$PROVISIONING_INTERFACE" ]; then
   fi
 fi
 
-if [ -n "$PROVISIONING_INTERFACE" ]; then
-  # Check provisioning interface is already set to ip address
-  if [[ -n $(ip -o addr show dev "${PROVISIONING_INTERFACE}" scope global) ]]; then
-    # equality check can be done for IPv4, i.e. 172.22.0.3/24
-    # for IPv6 and dualstack(IPv4v6), fd00:1101::x/64 is used as fd00:1101::xxxx:xxxx:xxxx:xxxx/128
-    # Thus, we need to parse provisioning ip with '::'.
-    if ! ip -o addr show dev "${PROVISIONING_INTERFACE}" scope global | grep -q "${PROVISIONING_IP//::*/}" ; then
-      echo "ERROR: \"$PROVISIONING_INTERFACE\" is already set to ip address belong to different subset than \"$PROVISIONING_IP\""
-      exit 1
-    fi
-  fi
-
-  # Get rid of any DHCP addresses on the dedicated provisioning interface
-  /usr/sbin/ip address flush dev "$PROVISIONING_INTERFACE" scope global
-
-  # Need this to be long enough to bring up the pod with the ip refresh in it.
-  # The refresh-static-ip container should lower this back to 10 seconds once it starts.
-  # The only time this will actually be set for 5 minutes is if the containers fail to come up.
-  /usr/sbin/ip addr add "$PROVISIONING_IP" dev "$PROVISIONING_INTERFACE" valid_lft 300 preferred_lft 300
-else
+if [ -z "${PROVISIONING_INTERFACE}" ]; then
   echo "ERROR: Could not find suitable interface for \"$PROVISIONING_IP\""
   exit 1
 fi
+
+# Check provisioning interface is already set to ip address
+if [[ -n $(ip -o addr show dev "${PROVISIONING_INTERFACE}" scope global) ]]; then
+  # equality check can be done for IPv4, i.e. 172.22.0.3/24
+  # for IPv6 and dualstack(IPv4v6), fd00:1101::x/64 is used as fd00:1101::xxxx:xxxx:xxxx:xxxx/128
+  # Thus, we need to parse provisioning ip with '::'.
+  if ! ip -o addr show dev "${PROVISIONING_INTERFACE}" scope global | grep -q "${PROVISIONING_IP//::*/}" ; then
+    echo "ERROR: \"$PROVISIONING_INTERFACE\" is already set to ip address belong to different subset than \"$PROVISIONING_IP\""
+    exit 1
+  fi
+fi
+
+# Get rid of any DHCP addresses on the dedicated provisioning interface
+/usr/sbin/ip address flush dev "$PROVISIONING_INTERFACE" scope global
+
+# Need this to be long enough to bring up the pod with the ip refresh in it.
+# The refresh-static-ip container should lower this back to 10 seconds once it starts.
+# The only time this will actually be set for 5 minutes is if the containers fail to come up.
+/usr/sbin/ip addr add "$PROVISIONING_IP" dev "$PROVISIONING_INTERFACE" valid_lft 300 preferred_lft 300

--- a/set-static-ip
+++ b/set-static-ip
@@ -8,8 +8,8 @@ fi
 if [ -z "$PROVISIONING_INTERFACE" ]; then
   if [ -n "${PROVISIONING_MACS}" ]; then
     for mac in ${PROVISIONING_MACS//,/ } ; do
-      if ip -br link show up | grep -qi "$mac"; then
-        PROVISIONING_INTERFACE=$(ip -br link show up | grep -i "$mac" | cut -f 1 -d ' ')
+      PROVISIONING_INTERFACE="$(ip -j link show up | jq -r ".[] | select(.address == \"${mac@L}\").ifname" | head -n 1)"
+      if [ -n "${PROVISIONING_INTERFACE}" ]; then
         break
       fi
     done

--- a/set-static-ip
+++ b/set-static-ip
@@ -52,7 +52,8 @@ if [ -n "$(ip -o addr show dev "${PROVISIONING_INTERFACE}" scope global)" ]; the
   fi
 fi
 
-# Get rid of any DHCP addresses on the dedicated provisioning interface
+# Get rid of any DHCP addresses on the dedicated provisioning interface.
+# These may be added by dnsmasq in a previous incarnation of the pod.
 /usr/sbin/ip address flush dev "$PROVISIONING_INTERFACE" scope global
 
 # Need this to be long enough to bring up the pod with the ip refresh in it.

--- a/set-static-ip
+++ b/set-static-ip
@@ -21,7 +21,7 @@ if [ -z "${PROVISIONING_INTERFACE}" ]; then
   exit 1
 fi
 
-if [[ -n $(ip -o addr show dev "${PROVISIONING_INTERFACE}" scope global) ]]; then
+if [ -n "$(ip -o addr show dev "${PROVISIONING_INTERFACE}" scope global)" ]; then
 
   function provisioning_net_valid() {
     local prov_vip_prefixlen

--- a/set-static-ip
+++ b/set-static-ip
@@ -21,13 +21,33 @@ if [ -z "${PROVISIONING_INTERFACE}" ]; then
   exit 1
 fi
 
-# Check provisioning interface is already set to ip address
 if [[ -n $(ip -o addr show dev "${PROVISIONING_INTERFACE}" scope global) ]]; then
-  # equality check can be done for IPv4, i.e. 172.22.0.3/24
-  # for IPv6 and dualstack(IPv4v6), fd00:1101::x/64 is used as fd00:1101::xxxx:xxxx:xxxx:xxxx/128
-  # Thus, we need to parse provisioning ip with '::'.
-  if ! ip -o addr show dev "${PROVISIONING_INTERFACE}" scope global | grep -q "${PROVISIONING_IP//::*/}" ; then
-    echo "ERROR: \"$PROVISIONING_INTERFACE\" is already set to ip address belong to different subset than \"$PROVISIONING_IP\""
+
+  function provisioning_net_valid() {
+    local prov_vip_prefixlen
+    prov_vip_prefixlen="$(ipcalc --no-decorate --prefix "${PROVISIONING_IP}")"
+
+    for ip_addr in $(ip -j -o addr show dev "${PROVISIONING_INTERFACE}" | jq -r '.[0].addr_info[] | select(.scope == "global").local'); do
+      # for IPv6 and dualstack(IPv4v6), fd00:1101::x/64 provisioning VIP
+      # has DHCP IP like fd00:1101::xxxx:xxxx:xxxx:xxxx/128
+      # Thus, we need to compare using the VIP's prefix length
+      local host_ip_cidr="${ip_addr}/${prov_vip_prefixlen}"
+      if ! ipcalc --check "${host_ip_cidr}" >/dev/null; then
+          continue
+      fi
+      if [ "$(ipcalc --no-decorate --network "${host_ip_cidr}")" = \
+          "$(ipcalc --no-decorate --network "${PROVISIONING_IP}")" ]; then
+        return 0
+      fi
+    done
+    echo "ERROR: provisioning interface \"${PROVISIONING_INTERFACE}\" IP addresses are all outside the provisioning subnet \"${PROVISIONING_IP}\""
+    return 1
+  }
+
+  # Check that we are not about to reconfigure an interface that is already
+  # configured for a different network, which may indicate that we are dealing
+  # with the machine network.
+  if ! provisioning_net_valid; then
     exit 1
   fi
 fi


### PR DESCRIPTION
Fix the validation from [METAL-67](https://issues.redhat.com/browse/METAL-67) to not crashloop until a previous incarnation of dnsmasq's DHCP addresses have timed out. Use structured tools instead of grepping text output to ensure robustness regardless of input.